### PR TITLE
지원하지 않는 이메일 형식 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This repository is choco-ice-moremi's code.
 GPL 3.0
 
 [Made]
-- studio moremi
- - cookedas1 (code)
+- studio moremi (op@kkutu.store)
+ - [cookedas1](https://github.com/cookedas1) (code)
 
 [Use laugage]
 - nodejs 18.0.0

--- a/commands/attendance.js
+++ b/commands/attendance.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
-- support@studio-moremi.kro.kr
+- op@kkutu.store
 */
 /**
  * 쿸으다스 수정 (9 ~ 94)

--- a/commands/co-farm.js
+++ b/commands/co-farm.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 /**
  * 쿸으다스 수정 (92 ~ 127)

--- a/commands/createuser.js
+++ b/commands/createuser.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
-- support@studio-moremi.kro.kr
+- op@kkutu.store
 */
 /**
  * 쿸으다스 수정 (65)

--- a/commands/farm.js
+++ b/commands/farm.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require('discord.js');
 const db = require('../utils/db');

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 /**
 * 쿸으다스 수정

--- a/commands/infobot.js
+++ b/commands/infobot.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 const { EmbedBuilder } = require('discord.js');
 

--- a/commands/inventory.js
+++ b/commands/inventory.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const db = require('../utils/db');

--- a/commands/license.js
+++ b/commands/license.js
@@ -1,7 +1,7 @@
 /* 본 코드를 지울 시 라이선스 삭제로 간주합니다
 License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 

--- a/commands/mailbox.js
+++ b/commands/mailbox.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 const { EmbedBuilder } = require('discord.js');
 

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,6 +1,6 @@
 /* License is GPL 3.0.
 - made by studio moremi
-- support@studio-moremi.kro.kr
+- op@kkutu.store
 */
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');

--- a/utils/level.js
+++ b/utils/level.js
@@ -1,5 +1,5 @@
 /* License is GPL 3.0.
 - made by studio moremi
- - support@studio-moremi.kro.kr
+ - op@kkutu.store
 */
 // 레벨 관련 설정 파일


### PR DESCRIPTION
기존 support@studio-moremi.kro.kr는 kro.kr 형식의 이메일을 라우팅 되지 않아 임시로 끄투의 문의 이메일로 변경 (op@kkutu.store)